### PR TITLE
Include dpkg options to keep old config files when upgrading filebeat

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ filebeat CHANGELOG
 
 This file is used to list changes made in each version of the filebeat cookbook.
 
+0.1.1
+-----
+
+- Brandon Wilson - Include dpkg options to keep old config files when upgrading filebeat to a new release. Without specifying the dpkg options, dpkg will attempt to interactively ask if it should keep the old conf file, or replace it with the vendor supplied conf file which comes with the new version of the package. Since chef is running dpkg non-interactively, it causes dpkg to exit with code 1, and the chef run fails.
+
+
 0.1.0
 -----
 

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -26,6 +26,6 @@ end
 
 package 'filebeat' do
   source package_file
-  options '--force-confdef --force-confold'
+  options '--force-confdef --force-confold' if node['platform_family'] == 'debian'
   provider Chef::Provider::Package::Dpkg if node['platform_family'] == 'debian'
 end

--- a/recipes/install.rb
+++ b/recipes/install.rb
@@ -26,5 +26,6 @@ end
 
 package 'filebeat' do
   source package_file
+  options '--force-confdef --force-confold'
   provider Chef::Provider::Package::Dpkg if node['platform_family'] == 'debian'
 end


### PR DESCRIPTION
Include dpkg options to keep old config files when upgrading filebeat to a new release. Without specifying the dpkg options, dpkg will attempt to interactively ask if it should keep the old conf file, or replace it with the vendor supplied conf file which comes with the new version of the package. Since chef is running dpkg non-interactively, it causes dpkg to exit with code 1, and the chef run fails.
