### PR TITLE
Adds a tag to berksfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ cookbook 'filebeat', '~> 0.2.7'
 ## From Git
 
 ```
-cookbook 'filebeat', github: 'vkhatri/chef-filebeat'
+cookbook 'filebeat', github: 'vkhatri/chef-filebeat',  tag: "v0.2.7"
 ```
 
 ## Repository


### PR DESCRIPTION
It is dangerous to use berkshelf against a git repo since berks will always fetch the latest commit. It also misleads the user into thinking that they have a specific cookbook version, when really the cookbook version is whatever HEAD was set to on the last fetch. It is safer to recommend users pin to a specific tag.
