### PR TITLE
Fixing issue with patterns and older versions of Ruby

### DIFF
--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -18,7 +18,7 @@
 #
 
 # Filebeat and psych v1.x don't get along.
-if(Psych::VERSION.start_with?("1"))
+if Psych::VERSION.start_with?('1')
   defaultengine = YAML::ENGINE.yamler
   YAML::ENGINE.yamler = 'syck'
 end
@@ -62,7 +62,5 @@ service 'filebeat' do
   action service_action
 end
 
-#and put this back the way we found them.
-if(Psych::VERSION.start_with?("1"))
-  YAML::ENGINE.yamler = defaultengine 
-end
+# ...and put this back the way we found them.
+YAML::ENGINE.yamler = defaultengine if Psych::VERSION.start_with?('1')

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -17,6 +17,12 @@
 # limitations under the License.
 #
 
+# Filebeat and psych v1.x don't get along.
+if(Psych::VERSION.start_with?("1"))
+  defaultengine = YAML::ENGINE.yamler
+  YAML::ENGINE.yamler = 'syck'
+end
+
 directory node['filebeat']['prospectors_dir'] do
   recursive true
   action :create
@@ -54,4 +60,9 @@ service_action = node['filebeat']['disable_service'] ? [:disable, :stop] : [:ena
 service 'filebeat' do
   supports :status => true, :restart => true
   action service_action
+end
+
+#and put this back the way we found them.
+if(Psych::VERSION.start_with?("1"))
+  YAML::ENGINE.yamler = defaultengine 
 end


### PR DESCRIPTION
Psych 1.x very strictly adheres to yaml standards and adds a ! in front of some strings, namely multilines patterns. Filebeat does not agree with this. As a sort of workaround, we can switch to Syck if we are using an older version of Pysch. Psych 2 works fine and Syck was removed. 
