### PR TITLE
Fixed default Install paths for windows.

### DIFF
--- a/attributes/config.rb
+++ b/attributes/config.rb
@@ -9,9 +9,9 @@ default['filebeat']['config']['filebeat']['prospectors'] = []
 # default['filebeat']['config']['filebeat']['spool_size'] = 1024
 # default['filebeat']['config']['filebeat']['idle_timeout'] =  '5s'
 default['filebeat']['config']['filebeat']['registry_file'] = if node['platform'] == 'windows'
-                                                                "#{node['filebeat']['conf_dir']}/registry"
+                                                               "#{node['filebeat']['conf_dir']}/registry"
                                                              else
-                                                                '/var/lib/filebeat/registry'
+                                                               '/var/lib/filebeat/registry'
                                                              end
 default['filebeat']['config']['filebeat']['config_dir'] = node['filebeat']['prospectors_dir']
 =begin

--- a/attributes/config.rb
+++ b/attributes/config.rb
@@ -9,8 +9,28 @@ default['filebeat']['prospectors'] = {}
 default['filebeat']['config']['filebeat']['prospectors'] = []
 # default['filebeat']['config']['filebeat']['spool_size'] = 1024
 # default['filebeat']['config']['filebeat']['idle_timeout'] =  '5s'
-default['filebeat']['config']['filebeat']['registry_file'] = '/var/lib/filebeat/registry'
+
+case node['platform']
+  when 'windows'
+    default['filebeat']['config']['filebeat']['registry_file'] = "#{node['filebeat']['conf_dir']}/registry"
+  else
+    default['filebeat']['config']['filebeat']['registry_file'] = '/var/lib/filebeat/registry'
+end
+
 default['filebeat']['config']['filebeat']['config_dir'] = node['filebeat']['prospectors_dir']
+
+
+=begin
+# Add Prospectors using Node Attribute Example
+apache_logs = {
+    'paths' => ["/var/log/apache/*.log"],
+    'input_type' => "log",
+    'fields' => {  'logtype' => "apache"  },
+    'document_type' => "apache",
+    'fields_under_root' => true
+}
+default['filebeat']['prospectors']['access']['filebeat']['prospectors'] = [apache_logs]
+=end
 
 default['filebeat']['config']['output'] = {}
 # elasticsearch host info
@@ -26,11 +46,21 @@ default['filebeat']['config']['output'] = {}
 # default['filebeat']['config']['output']['elasticsearch']['index'] = 'filebeat'
 # default['filebeat']['config']['output']['elasticsearch']['path'] = '/elasticsearch'
 
+# Logstash Output config info
 # default['filebeat']['config']['output']['logstash']['enabled'] = false
 # default['filebeat']['config']['output']['logstash']['hosts'] = []
 # default['filebeat']['config']['output']['logstash']['loadbalance'] = true
 # default['filebeat']['config']['output']['logstash']['save_topology'] = true
 # default['filebeat']['config']['output']['logstash']['index'] = 'filebeat'
+
+
+# Logging Output configs
+#default['filebeat']['config']['logging']['to_files'] = true
+#if node['platform'] == 'windows'
+#  default['filebeat']['config']['logging']['files']['path'] = '"#{node['filebeat']['conf_dir']}/logs"'
+#end
+#default['filebeat']['config']['logging']['files']['rotateeverybytes'] = 10485760
+#default['filebeat']['config']['logging']['level'] = 'info'
 
 # default['filebeat']['config']['output']['file']['enabled'] = false
 # default['filebeat']['config']['output']['file']['path'] = '/tmp/filebeat'

--- a/attributes/config.rb
+++ b/attributes/config.rb
@@ -8,11 +8,11 @@ default['filebeat']['prospectors'] = {}
 default['filebeat']['config']['filebeat']['prospectors'] = []
 # default['filebeat']['config']['filebeat']['spool_size'] = 1024
 # default['filebeat']['config']['filebeat']['idle_timeout'] =  '5s'
-if node['platform'] == 'windows'
-  default['filebeat']['config']['filebeat']['registry_file'] = "#{node['filebeat']['conf_dir']}/registry"
-else
-  default['filebeat']['config']['filebeat']['registry_file'] = '/var/lib/filebeat/registry'
-end
+default['filebeat']['config']['filebeat']['registry_file'] = if node['platform'] == 'windows'
+                                                               "#{node['filebeat']['conf_dir']}/registry"
+                                                             else
+                                                               '/var/lib/filebeat/registry'
+                                                             end
 default['filebeat']['config']['filebeat']['config_dir'] = node['filebeat']['prospectors_dir']
 =begin
 # Add Prospectors using Node Attribute Example

--- a/attributes/config.rb
+++ b/attributes/config.rb
@@ -9,9 +9,9 @@ default['filebeat']['config']['filebeat']['prospectors'] = []
 # default['filebeat']['config']['filebeat']['spool_size'] = 1024
 # default['filebeat']['config']['filebeat']['idle_timeout'] =  '5s'
 if node['platform'] == 'windows'
-    default['filebeat']['config']['filebeat']['registry_file'] = "#{node['filebeat']['conf_dir']}/registry"
-  else
-    default['filebeat']['config']['filebeat']['registry_file'] = '/var/lib/filebeat/registry'
+  default['filebeat']['config']['filebeat']['registry_file'] = "#{node['filebeat']['conf_dir']}/registry"
+else
+  default['filebeat']['config']['filebeat']['registry_file'] = '/var/lib/filebeat/registry'
 end
 default['filebeat']['config']['filebeat']['config_dir'] = node['filebeat']['prospectors_dir']
 =begin

--- a/attributes/config.rb
+++ b/attributes/config.rb
@@ -4,22 +4,17 @@
 
 # prospector configuration files
 default['filebeat']['prospectors'] = {}
-
 # prospector configuration
 default['filebeat']['config']['filebeat']['prospectors'] = []
 # default['filebeat']['config']['filebeat']['spool_size'] = 1024
 # default['filebeat']['config']['filebeat']['idle_timeout'] =  '5s'
-
 case node['platform']
   when 'windows'
     default['filebeat']['config']['filebeat']['registry_file'] = "#{node['filebeat']['conf_dir']}/registry"
   else
     default['filebeat']['config']['filebeat']['registry_file'] = '/var/lib/filebeat/registry'
 end
-
 default['filebeat']['config']['filebeat']['config_dir'] = node['filebeat']['prospectors_dir']
-
-
 =begin
 # Add Prospectors using Node Attribute Example
 apache_logs = {
@@ -31,7 +26,6 @@ apache_logs = {
 }
 default['filebeat']['prospectors']['access']['filebeat']['prospectors'] = [apache_logs]
 =end
-
 default['filebeat']['config']['output'] = {}
 # elasticsearch host info
 # default['filebeat']['config']['output']['elasticsearch']['enabled'] = true
@@ -53,14 +47,13 @@ default['filebeat']['config']['output'] = {}
 # default['filebeat']['config']['output']['logstash']['save_topology'] = true
 # default['filebeat']['config']['output']['logstash']['index'] = 'filebeat'
 
-
 # Logging Output configs
-#default['filebeat']['config']['logging']['to_files'] = true
-#if node['platform'] == 'windows'
+# default['filebeat']['config']['logging']['to_files'] = true
+# if node['platform'] == 'windows'
 #  default['filebeat']['config']['logging']['files']['path'] = '"#{node['filebeat']['conf_dir']}/logs"'
-#end
-#default['filebeat']['config']['logging']['files']['rotateeverybytes'] = 10485760
-#default['filebeat']['config']['logging']['level'] = 'info'
+# end
+# default['filebeat']['config']['logging']['files']['rotateeverybytes'] = 10485760
+# default['filebeat']['config']['logging']['level'] = 'info'
 
 # default['filebeat']['config']['output']['file']['enabled'] = false
 # default['filebeat']['config']['output']['file']['path'] = '/tmp/filebeat'

--- a/attributes/config.rb
+++ b/attributes/config.rb
@@ -8,8 +8,7 @@ default['filebeat']['prospectors'] = {}
 default['filebeat']['config']['filebeat']['prospectors'] = []
 # default['filebeat']['config']['filebeat']['spool_size'] = 1024
 # default['filebeat']['config']['filebeat']['idle_timeout'] =  '5s'
-case node['platform']
-  when 'windows'
+if node['platform'] == 'windows'
     default['filebeat']['config']['filebeat']['registry_file'] = "#{node['filebeat']['conf_dir']}/registry"
   else
     default['filebeat']['config']['filebeat']['registry_file'] = '/var/lib/filebeat/registry'

--- a/attributes/config.rb
+++ b/attributes/config.rb
@@ -9,9 +9,9 @@ default['filebeat']['config']['filebeat']['prospectors'] = []
 # default['filebeat']['config']['filebeat']['spool_size'] = 1024
 # default['filebeat']['config']['filebeat']['idle_timeout'] =  '5s'
 default['filebeat']['config']['filebeat']['registry_file'] = if node['platform'] == 'windows'
-                                                               "#{node['filebeat']['conf_dir']}/registry"
+                                                                "#{node['filebeat']['conf_dir']}/registry"
                                                              else
-                                                               '/var/lib/filebeat/registry'
+                                                                '/var/lib/filebeat/registry'
                                                              end
 default['filebeat']['config']['filebeat']['config_dir'] = node['filebeat']['prospectors_dir']
 =begin

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -7,14 +7,14 @@ default['filebeat']['windows'] = {
     'base_dir' => 'C:/opt/filebeat'
 }
 default['filebeat']['conf_dir'] = if node['platform'] == 'windows'
-                                      "#{node['filebeat']['windows']['base_dir']}/filebeat-#{node['filebeat']['version']}-windows"
+                                     "#{node['filebeat']['windows']['base_dir']}/filebeat-#{node['filebeat']['version']}-windows"
                                   else
-                                      '/etc/filebeat'
+                                     '/etc/filebeat'
                                   end
 default['filebeat']['conf_file'] = if node['platform'] == 'windows'
-                                      "#{node['filebeat']['conf_dir']}/filebeat.yml"
+                                     "#{node['filebeat']['conf_dir']}/filebeat.yml"
                                   else
-                                      ::File.join(node['filebeat']['conf_dir'], 'filebeat.yml')
+                                     ::File.join(node['filebeat']['conf_dir'], 'filebeat.yml')
                                   end
 default['filebeat']['prospectors_dir'] = if node['platform'] == 'windows'
                                             "#{node['filebeat']['conf_dir']}/conf.d"

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,15 +1,24 @@
-default['filebeat']['version'] = '1.1.2'
+default['filebeat']['version'] = '1.2.1'
 default['filebeat']['disable_service'] = false
 default['filebeat']['package_url'] = 'auto'
 
 default['filebeat']['notify_restart'] = true
-default['filebeat']['conf_dir'] = '/etc/filebeat'
-default['filebeat']['prospectors_dir'] = ::File.join(node['filebeat']['conf_dir'], 'conf.d')
-default['filebeat']['conf_file'] = ::File.join(node['filebeat']['conf_dir'], 'filebeat.yml')
-
 default['filebeat']['windows'] = {
-  'base_dir' => 'C:/opt/filebeat/'
+    'base_dir' => 'C:/opt/filebeat'
 }
+
+if node['platform'] == 'windows'
+  default['filebeat']['conf_dir'] = "#{node['filebeat']['windows']['base_dir']}/filebeat-#{node['filebeat']['version']}-windows"
+  default['filebeat']['conf_file'] = "#{node['filebeat']['conf_dir']}/filebeat.yml"
+  default['filebeat']['prospectors_dir'] = "#{node['filebeat']['conf_dir']}/conf.d"
+else
+  default['filebeat']['conf_dir'] = '/etc/filebeat'
+  default['filebeat']['prospectors_dir'] = ::File.join(node['filebeat']['conf_dir'], 'conf.d')
+  default['filebeat']['conf_file'] = ::File.join(node['filebeat']['conf_dir'], 'filebeat.yml')
+end
+
+
+
 
 default['filebeat']['yum']['baseurl'] = 'https://packages.elastic.co/beats/yum/el/$basearch'
 default['filebeat']['yum']['description'] = 'Elastic Beats Repository'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,23 +3,21 @@ default['filebeat']['disable_service'] = false
 default['filebeat']['package_url'] = 'auto'
 
 default['filebeat']['notify_restart'] = true
-default['filebeat']['windows'] = {
-    'base_dir' => 'C:/opt/filebeat'
-}
+default['filebeat']['windows'] = {  'base_dir' => 'C:/opt/filebeat'}
 default['filebeat']['conf_dir'] = if node['platform'] == 'windows'
-                                     "#{node['filebeat']['windows']['base_dir']}/filebeat-#{node['filebeat']['version']}-windows"
+                                    "#{node['filebeat']['windows']['base_dir']}/filebeat-#{node['filebeat']['version']}-windows"
                                   else
-                                     '/etc/filebeat'
+                                    '/etc/filebeat'
                                   end
 default['filebeat']['conf_file'] = if node['platform'] == 'windows'
                                      "#{node['filebeat']['conf_dir']}/filebeat.yml"
-                                  else
+                                   else
                                      ::File.join(node['filebeat']['conf_dir'], 'filebeat.yml')
-                                  end
+                                   end
 default['filebeat']['prospectors_dir'] = if node['platform'] == 'windows'
-                                            "#{node['filebeat']['conf_dir']}/conf.d"
+                                           "#{node['filebeat']['conf_dir']}/conf.d"
                                          else
-                                            ::File.join(node['filebeat']['conf_dir'], 'conf.d')
+                                           ::File.join(node['filebeat']['conf_dir'], 'conf.d')
                                          end
 default['filebeat']['yum']['baseurl'] = 'https://packages.elastic.co/beats/yum/el/$basearch'
 default['filebeat']['yum']['description'] = 'Elastic Beats Repository'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -3,7 +3,7 @@ default['filebeat']['disable_service'] = false
 default['filebeat']['package_url'] = 'auto'
 
 default['filebeat']['notify_restart'] = true
-default['filebeat']['windows'] = {  'base_dir' => 'C:/opt/filebeat'}
+default['filebeat']['windows'] = { 'base_dir' => 'C:/opt/filebeat' }
 default['filebeat']['conf_dir'] = if node['platform'] == 'windows'
                                     "#{node['filebeat']['windows']['base_dir']}/filebeat-#{node['filebeat']['version']}-windows"
                                   else

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -7,19 +7,19 @@ default['filebeat']['windows'] = {
     'base_dir' => 'C:/opt/filebeat'
 }
 default['filebeat']['conf_dir'] = if node['platform'] == 'windows'
-                                    "#{node['filebeat']['windows']['base_dir']}/filebeat-#{node['filebeat']['version']}-windows"
+                                      "#{node['filebeat']['windows']['base_dir']}/filebeat-#{node['filebeat']['version']}-windows"
                                   else
-                                    '/etc/filebeat'
+                                      '/etc/filebeat'
                                   end
-default['filebeat']['conf_file'] =if node['platform'] == 'windows'
-                                    "#{node['filebeat']['conf_dir']}/filebeat.yml"
+default['filebeat']['conf_file'] = if node['platform'] == 'windows'
+                                      "#{node['filebeat']['conf_dir']}/filebeat.yml"
                                   else
-                                    ::File.join(node['filebeat']['conf_dir'], 'filebeat.yml')
+                                      ::File.join(node['filebeat']['conf_dir'], 'filebeat.yml')
                                   end
 default['filebeat']['prospectors_dir'] = if node['platform'] == 'windows'
-                                           "#{node['filebeat']['conf_dir']}/conf.d"
+                                            "#{node['filebeat']['conf_dir']}/conf.d"
                                          else
-                                           ::File.join(node['filebeat']['conf_dir'], 'conf.d')
+                                            ::File.join(node['filebeat']['conf_dir'], 'conf.d')
                                          end
 default['filebeat']['yum']['baseurl'] = 'https://packages.elastic.co/beats/yum/el/$basearch'
 default['filebeat']['yum']['description'] = 'Elastic Beats Repository'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,15 +6,21 @@ default['filebeat']['notify_restart'] = true
 default['filebeat']['windows'] = {
     'base_dir' => 'C:/opt/filebeat'
 }
-if node['platform'] == 'windows'
-  default['filebeat']['conf_dir'] = "#{node['filebeat']['windows']['base_dir']}/filebeat-#{node['filebeat']['version']}-windows"
-  default['filebeat']['conf_file'] = "#{node['filebeat']['conf_dir']}/filebeat.yml"
-  default['filebeat']['prospectors_dir'] = "#{node['filebeat']['conf_dir']}/conf.d"
-else
-  default['filebeat']['conf_dir'] = '/etc/filebeat'
-  default['filebeat']['prospectors_dir'] = ::File.join(node['filebeat']['conf_dir'], 'conf.d')
-  default['filebeat']['conf_file'] = ::File.join(node['filebeat']['conf_dir'], 'filebeat.yml')
-end
+default['filebeat']['conf_dir'] = if node['platform'] == 'windows'
+                                    "#{node['filebeat']['windows']['base_dir']}/filebeat-#{node['filebeat']['version']}-windows"
+                                  else
+                                    '/etc/filebeat'
+                                  end
+default['filebeat']['conf_file'] =if node['platform'] == 'windows'
+                                    "#{node['filebeat']['conf_dir']}/filebeat.yml"
+                                  else
+                                    ::File.join(node['filebeat']['conf_dir'], 'filebeat.yml')
+                                  end
+default['filebeat']['prospectors_dir'] = if node['platform'] == 'windows'
+                                           "#{node['filebeat']['conf_dir']}/conf.d"
+                                         else
+                                           ::File.join(node['filebeat']['conf_dir'], 'conf.d')
+                                         end
 default['filebeat']['yum']['baseurl'] = 'https://packages.elastic.co/beats/yum/el/$basearch'
 default['filebeat']['yum']['description'] = 'Elastic Beats Repository'
 default['filebeat']['yum']['gpgcheck'] = true

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -6,7 +6,6 @@ default['filebeat']['notify_restart'] = true
 default['filebeat']['windows'] = {
     'base_dir' => 'C:/opt/filebeat'
 }
-
 if node['platform'] == 'windows'
   default['filebeat']['conf_dir'] = "#{node['filebeat']['windows']['base_dir']}/filebeat-#{node['filebeat']['version']}-windows"
   default['filebeat']['conf_file'] = "#{node['filebeat']['conf_dir']}/filebeat.yml"
@@ -16,10 +15,6 @@ else
   default['filebeat']['prospectors_dir'] = ::File.join(node['filebeat']['conf_dir'], 'conf.d')
   default['filebeat']['conf_file'] = ::File.join(node['filebeat']['conf_dir'], 'filebeat.yml')
 end
-
-
-
-
 default['filebeat']['yum']['baseurl'] = 'https://packages.elastic.co/beats/yum/el/$basearch'
 default['filebeat']['yum']['description'] = 'Elastic Beats Repository'
 default['filebeat']['yum']['gpgcheck'] = true

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -30,6 +30,14 @@ describe 'filebeat::default' do
 
     include_examples 'filebeat'
 
+    it 'create prospector directory /etc/filebeat/conf.d' do
+      expect(chef_run).to create_directory('/etc/filebeat/conf.d')
+    end
+
+    it 'configure /etc/filebeat/filebeat.yml' do
+      expect(chef_run).to create_file('/etc/filebeat/filebeat.yml')
+    end
+
     it 'adds beats yum repository' do
       expect(chef_run).to create_yum_repository('beats')
     end
@@ -51,6 +59,14 @@ describe 'filebeat::default' do
     end
 
     include_examples 'filebeat'
+
+    it 'create prospector directory /etc/filebeat/conf.d' do
+      expect(chef_run).to create_directory('/etc/filebeat/conf.d')
+    end
+
+    it 'configure /etc/filebeat/filebeat.yml' do
+      expect(chef_run).to create_file('/etc/filebeat/filebeat.yml')
+    end
 
     it 'adds beats apt repository' do
       expect(chef_run).to add_apt_repository('beats')
@@ -74,6 +90,14 @@ describe 'filebeat::default' do
 
     include_examples 'filebeat'
 
+    it 'create prospector directory C:/opt/filebeat/filebeat-1.2.1-windows/conf.d' do
+      expect(chef_run).to create_directory('C:/opt/filebeat/filebeat-1.2.1-windows/conf.d')
+    end
+
+    it 'configure C:/opt/filebeat/filebeat-1.2.1-windows/filebeat.yml' do
+      expect(chef_run).to create_file('C:/opt/filebeat/filebeat-1.2.1-windows/filebeat.yml')
+    end
+
     it 'include recipe filebeat::install_windows' do
       expect(chef_run).to include_recipe('filebeat::install_windows')
     end
@@ -82,12 +106,12 @@ describe 'filebeat::default' do
       expect(chef_run).to create_remote_file('filebeat_package_file')
     end
 
-    it 'create filebeat base dir C:/opt/filebeat/' do
-      expect(chef_run).to create_directory('C:/opt/filebeat/')
+    it 'create filebeat base dir C:/opt/filebeat' do
+      expect(chef_run).to create_directory('C:/opt/filebeat')
     end
 
-    it 'unzip filebeat package file to C:/opt/filebeat/' do
-      expect(chef_run).to unzip_windows_zipfile_to('C:/opt/filebeat/')
+    it 'unzip filebeat package file to C:/opt/filebeat' do
+      expect(chef_run).to unzip_windows_zipfile_to('C:/opt/filebeat')
     end
   end
 end

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -3,14 +3,6 @@ require 'spec_helper'
 describe 'filebeat::default' do
   shared_examples_for 'filebeat' do
     context 'all_platforms' do
-      it 'create prospector directory /etc/filebeat/conf.d' do
-        expect(chef_run).to create_directory('/etc/filebeat/conf.d')
-      end
-
-      it 'configure /etc/filebeat/filebeat.yml' do
-        expect(chef_run).to create_file('/etc/filebeat/filebeat.yml')
-      end
-
       it 'run ruby_block delay filebeat service start' do
         expect(chef_run).to run_ruby_block('delay filebeat service start')
       end


### PR DESCRIPTION
Fixed default Install paths for windows.
Added logging mappings for filbeats.
Added Example to show prospector use for node attributes.
Upgraded filebeat to 1.2.1
