### PR TITLE
Respect service flags on package installation

### DIFF
--- a/recipes/install_package.rb
+++ b/recipes/install_package.rb
@@ -43,5 +43,5 @@ end
 package 'filebeat' do
   version node['platform_family'] == 'rhel' ? node['filebeat']['version'] + '-1' : node['filebeat']['version']
   options node['filebeat']['apt']['options'] if node['filebeat']['apt']['options'] && node['platform_family'] == 'debian'
-  notifies :restart, 'service[filebeat]'
+  notifies :restart, 'service[filebeat]' if node['filebeat']['notify_restart'] && !node['filebeat']['disable_service']
 end


### PR DESCRIPTION
When doing local development, we want to skip filebeat from starting; unfortunately, this cookbook sends a notification no matter what during the install recipe. This adds a conditional for now sending :start to the service only when the conditional is met.
