### PR TITLE
Support spaces in file path.

### DIFF
--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -44,7 +44,7 @@ prospectors.each do |prospector, configuration|
 end
 
 powershell 'install filebeat as service' do
-  code "#{node['filebeat']['windows']['base_dir']}/filebeat-#{node['filebeat']['version']}-windows/install-service-filebeat.ps1"
+  code "& '#{node['filebeat']['windows']['base_dir']}/filebeat-#{node['filebeat']['version']}-windows/install-service-filebeat.ps1'"
   only_if { node['platform'] == 'windows' }
 end
 


### PR DESCRIPTION
In case of installation to a path with spaces, e.g. 'C:\Program Files\Filebeat', current code fails with:
STDERR: C:\Program : The term 'C:\Program' is not recognized as the name of a cmdlet, function, script file, or operable program. Check the spelling of the name, or if a path was included, verify that the path is correct and try again.

To fix this we need an execution with quotes.
