### PR TITLE
Remove enabled attribute for now

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,7 +113,6 @@ end
       "config": {
         "output": {
           "elasticsearch": {
-            "enabled": true,
             "hosts": ["127.0.0.1:9200"],
             "save_topology": false,
             "max_retries": 3,
@@ -141,7 +140,6 @@ end
       "config": {
         "output": {
           "logstash": {
-            "enabled": true,
             "hosts": ["127.0.0.1:5000"],
             "loadbalance": true,
             "save_topology": false,
@@ -162,7 +160,6 @@ end
       "config": {
         "output": {
           "file": {
-            "enabled": true,
             "path": "/tmp/filebeat",
             "filename": "filebeat",
             "rotate_every_kb": 1000,

--- a/attributes/config.rb
+++ b/attributes/config.rb
@@ -27,7 +27,6 @@ default['filebeat']['prospectors']['access']['filebeat']['prospectors'] = [apach
 =end
 default['filebeat']['config']['output'] = {}
 # elasticsearch host info
-# default['filebeat']['config']['output']['elasticsearch']['enabled'] = true
 # default['filebeat']['config']['output']['elasticsearch']['hosts'] = []
 # default['filebeat']['config']['output']['elasticsearch']['save_topology'] = false
 # default['filebeat']['config']['output']['elasticsearch']['max_retries'] = 3
@@ -40,7 +39,6 @@ default['filebeat']['config']['output'] = {}
 # default['filebeat']['config']['output']['elasticsearch']['path'] = '/elasticsearch'
 
 # Logstash Output config info
-# default['filebeat']['config']['output']['logstash']['enabled'] = false
 # default['filebeat']['config']['output']['logstash']['hosts'] = []
 # default['filebeat']['config']['output']['logstash']['loadbalance'] = true
 # default['filebeat']['config']['output']['logstash']['save_topology'] = true
@@ -54,7 +52,6 @@ default['filebeat']['config']['output'] = {}
 # default['filebeat']['config']['logging']['files']['rotateeverybytes'] = 10485760
 # default['filebeat']['config']['logging']['level'] = 'info'
 
-# default['filebeat']['config']['output']['file']['enabled'] = false
 # default['filebeat']['config']['output']['file']['path'] = '/tmp/filebeat'
 # default['filebeat']['config']['output']['file']['filename'] = 'filebeat'
 # default['filebeat']['config']['output']['file']['rotate_every_kb'] = 1_000


### PR DESCRIPTION
# What

Remove the enabled attributes from the output configurations.  Prior to filebeat 1.0.0 being released you could set the enabled flag to true or false to turn an output on of off.  The feature was removed and at the moment you need to completely comment out or remove an output stanza to turn it off.
# How

Removed from the README file and the commented out attributes.  No effective change to how the recipe works but folks like myself won't go down the path of using the attribute only to find it doesn't work as expected.  
# Reference

Hopefully this will be added back to libbeat in the future as it is a super useful flag to have - especially in configuration management where you may want to override an output depending on role or environment.
https://github.com/elastic/beats/issues/1589
