### PR TITLE
Add enable attribute back to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ end
       "config": {
         "output": {
           "redis": {
+            "enable": true,
             "host": "127.0.0.1",
             "port": 6379,
             "save_topology": false,
@@ -141,6 +142,7 @@ end
       "config": {
         "output": {
           "elasticsearch": {
+            "enable": true,
             "hosts": ["127.0.0.1:9200"],
             "save_topology": false,
             "max_retries": 3,
@@ -173,6 +175,7 @@ end
       "config": {
         "output": {
           "logstash": {
+            "enable": true,
             "hosts": ["127.0.0.1:5000"],
             "loadbalance": true,
             "save_topology": false,

--- a/attributes/config.rb
+++ b/attributes/config.rb
@@ -26,6 +26,7 @@ default['filebeat']['prospectors']['access']['filebeat']['prospectors'] = [apach
 
 default['filebeat']['config']['output'] = {}
 # Elasticsearch host attributes
+# default['filebeat']['config']['output']['elasticsearch']['enable'] = true
 # default['filebeat']['config']['output']['elasticsearch']['hosts'] = []
 # default['filebeat']['config']['output']['elasticsearch']['save_topology'] = false
 # default['filebeat']['config']['output']['elasticsearch']['max_retries'] = 3
@@ -42,6 +43,7 @@ default['filebeat']['config']['output'] = {}
 # default['filebeat']['config']['output']['elasticsearch']['tls']['insecure'] = false
 
 # Logstash Output config attributes
+# default['filebeat']['config']['output']['logstash']['enable'] = true
 # default['filebeat']['config']['output']['logstash']['hosts'] = []
 # default['filebeat']['config']['output']['logstash']['loadbalance'] = true
 # default['filebeat']['config']['output']['logstash']['save_topology'] = true
@@ -52,6 +54,7 @@ default['filebeat']['config']['output'] = {}
 # default['filebeat']['config']['output']['logstash']['tls']['insecure'] = false
 
 # Redis Output config attributes
+# default['filebeat']['config']['output']['redis']['enable'] = true
 # default['filebeat']['config']['output']['redis']['host'] = 'locahost'
 # default['filebeat']['config']['output']['redis']['port'] = 6379
 # default['filebeat']['config']['output']['redis']['save_topology'] = false


### PR DESCRIPTION
# What

Add the enable attribute back to the README and comments in attributes/config.rb.  
# Why

The filebeat team has added this back into the various beats with this PR - https://github.com/elastic/beats/pull/1987 .
# Notes

This should not be merged until we have pinned to a release of filebeat which has this feature in it.  The feature is merged into filebeat master, but I have not confirmed if they have cut a new release yet which contains the code.  Looks like this will come out with version 5.0.0 - it is listed in the beta README now for 5.0.0-x
