### PR TITLE
Only call powershell resource on windows machines

### DIFF
--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -43,7 +43,7 @@ prospectors.each do |prospector, configuration|
   end
 end
 
-if node['platform'] == 'windows'
+if node['platform'] == 'windows' # ~FC023
   powershell 'install filebeat as service' do
     code "& '#{node['filebeat']['windows']['base_dir']}/filebeat-#{node['filebeat']['version']}-windows/install-service-filebeat.ps1'"
   end

--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -43,9 +43,10 @@ prospectors.each do |prospector, configuration|
   end
 end
 
-powershell 'install filebeat as service' do
-  code "& '#{node['filebeat']['windows']['base_dir']}/filebeat-#{node['filebeat']['version']}-windows/install-service-filebeat.ps1'"
-  only_if { node['platform'] == 'windows' }
+if node['platform'] == 'windows'
+  powershell 'install filebeat as service' do
+    code "& '#{node['filebeat']['windows']['base_dir']}/filebeat-#{node['filebeat']['version']}-windows/install-service-filebeat.ps1'"
+  end
 end
 
 ruby_block 'delay filebeat service start' do


### PR DESCRIPTION
The `powershell` resource isn't even defined on non-windows machines in
newer versions of Chef, so `only_if` is not sufficient to prevent
"resource not found" errors.

Note that this may actually be needed to address #64 because it also applies to `powershell_script`.
