### PR TITLE
Add support for using runit instead of the default init system

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -48,7 +48,39 @@ suites:
                 exclude_files:
                 - /var/log/messages
                 - /var/log/syslog
+        config:
+          output:
+            elasticsearch:
+              hosts: ["127.0.0.1:9200"]
 
+  - name: runit
+    require_chef_omnibus: 12.14.60
+    excludes:
+      - windows-2012R2 
+    run_list:
+      - recipe[filebeat::default]
+    attributes:
+      filebeat:
+        service:
+          init_style: 'runit'
+        prospectors:
+          system_logs:
+            filebeat:
+              prospectors:
+              - paths:
+                - /var/log/messages
+                - /var/log/syslog
+                type: log
+                fields:
+                  type: system_logs
+              - paths:
+                - /var/log/*.log
+                type: log
+                fields:
+                  type: undefined
+                exclude_files:
+                - /var/log/messages
+                - /var/log/syslog
         config:
           output:
             elasticsearch:

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -11,5 +11,6 @@ default['filebeat']['solaris'] = {
   'manifest_directory' => '/var/svc/manifest/application'
 }
 
+default['filebeat']['service']['init_style'] = 'init' # or runit
 default['filebeat']['service']['retries'] = 0
 default['filebeat']['service']['retry_delay'] = 2

--- a/metadata.rb
+++ b/metadata.rb
@@ -12,6 +12,7 @@ depends 'windows'
 depends 'apt'
 depends 'yum'
 depends 'yum-plugin-versionlock', '>= 0.1.2'
+depends 'runit'
 
 %w(windows ubuntu centos amazon redhat fedora).each do |os|
   supports os

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -13,6 +13,25 @@ describe 'filebeat::default' do
     end
   end
 
+  context 'runit' do
+    let(:chef_run) do
+      ChefSpec::SoloRunner.new(platform: 'centos', version: '6.8') do |node|
+        node.automatic['platform_family'] = 'rhel'
+        node.override['filebeat']['service']['init_style'] = 'runit'
+      end.converge(described_recipe)
+    end
+
+    let(:node) { chef_run.node }
+
+    it 'include runit::default recipe' do
+      expect(chef_run).to include_recipe('runit::default')
+    end
+
+    it 'enable filebeat runit service' do
+      expect(chef_run).to enable_runit_service('filebeat')
+    end
+  end
+
   context 'rhel' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'centos', version: '6.8') do |node|

--- a/templates/default/sv-filebeat-run.erb
+++ b/templates/default/sv-filebeat-run.erb
@@ -1,0 +1,3 @@
+#!/bin/sh
+exec 2>&1
+exec chpst -u <%= @options['user'] %> <%= @options['binary_path'] %> -c <%= @options['conf_path'] %>


### PR DESCRIPTION
I dislike runit as much as the next person but I am trying to run filebeat within a container which only has support for runit.
