### PR TITLE
Switch to platform_family

### DIFF
--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,7 +19,7 @@
 
 include_recipe 'filebeat::attributes'
 
-include_recipe 'yum-plugin-versionlock::default' if node['platform'] == 'rhel' || node['platform'] == 'centos'
+include_recipe 'yum-plugin-versionlock::default' if node['platform_family'] == 'rhel'
 
 # install filebeat
 case node['platform']


### PR DESCRIPTION
Hello,

I'm trying to use filebeat cookbooks to PCS6 that is RHEL family OS too but cookbook is locked to RHEL and CentOS only.
This PR fix this problem by using 'platform_family' instead of 'platform' for 'yum-plugins-versionlock' package installation.
