### PR TITLE
clear prospectors_dir on change

### DIFF
--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -25,7 +25,7 @@ end
 
 directory node['filebeat']['prospectors_dir'] do
   recursive true
-  action :create
+  action [:delete, :create]
 end
 
 file node['filebeat']['conf_file'] do


### PR DESCRIPTION
if you deploy a prospector then remove it, it sticks around. this change ensures the conf.d dir is clean everytime