### PR TITLE
added json attributes to filebeat_prospector

### DIFF
--- a/libraries/provider_prospector.rb
+++ b/libraries/provider_prospector.rb
@@ -54,6 +54,10 @@ class Chef
           content['publish_async'] = new_resource.publish_async if new_resource.publish_async
           content['idle_timeout'] = new_resource.idle_timeout if new_resource.idle_timeout
           content['registry_file'] = new_resource.registry_file if new_resource.registry_file
+          content['json.message_key'] = new_resource.json_message_key if new_resource.json_message_key
+          content['json.keys_under_root'] = new_resource.json_keys_under_root if new_resource.json_keys_under_root
+          content['json.overwrite_keys'] = new_resource.json_overwrite_keys if new_resource.json_overwrite_keys
+          content['json.add_error_key'] = new_resource.json_add_error_key if new_resource.json_add_error_key
         end
 
         file_content = { 'filebeat' => { 'prospectors' => [content] } }.to_yaml

--- a/libraries/resource_prospector.rb
+++ b/libraries/resource_prospector.rb
@@ -216,6 +216,35 @@ class Chef
           :default => nil
         )
       end
+
+      def json_message_key(arg = nil)
+        set_or_return(
+          :json_message_key, arg,
+          :kind_of => String,
+          :default => nil
+        )
+      end
+
+      def json_keys_under_root(arg = nil)
+        set_or_return(
+          :json_keys_under_root, arg,
+          :kind_of => [TrueClass, FalseClass]
+        )
+      end
+
+      def json_overwrite_keys(arg = nil)
+        set_or_return(
+          :json_overwrite_keys, arg,
+          :kind_of => [TrueClass, FalseClass]
+        )
+      end
+
+      def json_add_error_key(arg = nil)
+        set_or_return(
+          :json_add_error_key, arg,
+          :kind_of => [TrueClass, FalseClass]
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
Filebeat v5.0.0-alpha1 added support for decoding [JSON logs](https://www.elastic.co/guide/en/beats/filebeat/current/configuration-filebeat-options.html#config-json). 

This update will allow users with an up to date Filebeat to utilize that feature. I have tested that adding these options to prospectors on v1.3.1 doesn't cause obvious errors. 

Please review, and let me know if you have any questions. 