### PR TITLE
Added check to avoid restart if service is disabled or notify restart…

### DIFF
--- a/libraries/provider_prospector.rb
+++ b/libraries/provider_prospector.rb
@@ -66,7 +66,7 @@ class Chef
         t = file "prospector_#{new_resource.name}" do
           path ::File.join(node['filebeat']['prospectors_dir'], "prospector-#{new_resource.name}.yml")
           content file_content
-          notifies :restart, 'service[filebeat]'
+          notifies :restart, 'service[filebeat]' if node['filebeat']['notify_restart'] && !node['filebeat']['disable_service']
           action action
         end
         t.updated?


### PR DESCRIPTION
Hello. I found an issue where the filebeat service was still getting a restart notification, even though the attributes set to disable the service and notifications was set. I traced it to the provider and added the check used in the config.rb recipe and it worked as expected.