### PR TITLE
Filebeat config could contain sensitive information

### DIFF
--- a/recipes/config.rb
+++ b/recipes/config.rb
@@ -29,6 +29,7 @@ file node['filebeat']['conf_file'] do
   content JSON.parse(node['filebeat']['config'].to_json).to_yaml.lines.to_a[1..-1].join
   notifies :restart, "service[#{node['filebeat']['service']['name']}]" if node['filebeat']['notify_restart'] && !node['filebeat']['disable_service']
   mode 0o600
+  sensitive true
 end
 
 include_recipe 'filebeat::prospectors'


### PR DESCRIPTION
Change filebeat config resource to be a sensitive one so that secrets from it do not leak into chef logs.