### PR TITLE
Prospector configs may contain sensitive information

### DIFF
--- a/libraries/provider_prospector.rb
+++ b/libraries/provider_prospector.rb
@@ -99,6 +99,7 @@ class Chef
           content file_content
           notifies :restart, "service[#{node['filebeat']['service']['name']}]" if node['filebeat']['notify_restart'] && !node['filebeat']['disable_service']
           mode 0o600
+          sensitive true
           action action
         end
         t.updated?


### PR DESCRIPTION
When used with x-pack security, prospector configs may contain secrets for elasticsearch and need to be protected.