### PR TITLE
use unzip_windows_zipfile for unit test

### DIFF
--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -61,6 +61,7 @@ describe 'filebeat::default' do
     end
   end
 
+
   context 'rhel' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'centos', version: '6.8') do |node|
@@ -200,7 +201,7 @@ describe 'filebeat::default' do
     end
 
     it 'unzip filebeat package file to C:/opt/filebeat' do
-      expect(chef_run).to unzip_windows_zipfile_to('C:/opt/filebeat')
+      expect(chef_run).to unzip_windows_zipfile('C:/opt/filebeat')
     end
 
     it 'run powershell_script to install filebeat as service' do

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -61,7 +61,6 @@ describe 'filebeat::default' do
     end
   end
 
-
   context 'rhel' do
     let(:chef_run) do
       ChefSpec::SoloRunner.new(platform: 'centos', version: '6.8') do |node|


### PR DESCRIPTION
This is on a clean `git clone` && `rake spec` run.

Not sure why my local env would fail of CI appears to be working.

```
$ rake spec
/Users/michaelb/.rvm/rubies/ruby-2.3.1/bin/ruby -I/Users/michaelb/.rvm/gems/ruby-2.3.1/gems/rspec-core-3.7.1/lib:/Users/michaelb/.rvm/gems/ruby-2.3.1/gems/rspec-support-3.7.1/lib /Users/michaelb/.rvm/gems/ruby-2.3.1/gems/rspec-core-3.7.1/exe/rspec --pattern spec/\*\*\{,/\*/\*\*\}/\*_spec.rb
...................................F.......

Failures:

  1) filebeat::default windows unzip filebeat package file to C:/opt/filebeat
     Failure/Error: expect(chef_run).to unzip_windows_zipfile_to('C:/opt/filebeat')

     NoMethodError:
       undefined method `unzip_windows_zipfile_to' for #<RSpec::ExampleGroups::FilebeatDefault::Windows:0x007fe4215bdbe8>
       Did you mean?  unzip_windows_zipfile
                      zip_windows_zipfile
     # ./spec/unit/recipes/default_spec.rb:203:in `block (3 levels) in <top (required)>'

Finished in 7.96 seconds (files took 5.28 seconds to load)
43 examples, 1 failure

Failed examples:

rspec ./spec/unit/recipes/default_spec.rb:202 # filebeat::default windows unzip filebeat package file to C:/opt/filebeat
```

My environment:

```
$ ruby -v
ruby 2.3.1p112 (2016-04-26 revision 54768) [x86_64-darwin16]
$ rspec -v
RSpec 3.7
  - rspec-core 3.7.1
  - rspec-expectations 3.7.0
  - rspec-mocks 3.7.0
  - rspec-support 3.7.1
```