### PR TITLE
Making it possible to pass additional command line arguments to the filebeat service

### DIFF
--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -17,6 +17,9 @@ default['filebeat']['solaris'] = {
 
 default['filebeat']['service']['init_style'] = 'init' # or runit
 default['filebeat']['service']['name'] = 'filebeat'
+# see https://www.elastic.co/guide/en/beats/filebeat/current/command-line-options.html
+default['filebeat']['service']['additional_command_line_options'] = ''
+default['filebeat']['service']['ignore_failure'] = false
 default['filebeat']['service']['retries'] = 0
 default['filebeat']['service']['retry_delay'] = 2
 

--- a/recipes/service.rb
+++ b/recipes/service.rb
@@ -49,7 +49,7 @@ end
 service_action = node['filebeat']['disable_service'] ? %i[disable stop] : %i[enable nothing]
 
 if node['filebeat']['service']['init_style'] == 'runit'
-  runit_cmd = "/usr/share/filebeat/bin/filebeat -c #{node['filebeat']['conf_file']} -path.home /usr/share/filebeat -path.config #{node['filebeat']['conf_dir']} -path.data /var/lib/filebeat -path.logs /var/log/filebeat"
+  runit_cmd = "/usr/share/filebeat/bin/filebeat -c #{node['filebeat']['conf_file']} -path.home /usr/share/filebeat -path.config #{node['filebeat']['conf_dir']} -path.data /var/lib/filebeat -path.logs /var/log/filebeat #{node['filebeat']['service']['additional_command_line_options']}"
   runit_service node['filebeat']['service']['name'] do
     options(
       'user' => 'root',
@@ -57,6 +57,7 @@ if node['filebeat']['service']['init_style'] == 'runit'
     )
     default_logger true
     action service_action
+    ignore_failure node['filebeat']['service']['ignore_failure']
   end
 else
   service node['filebeat']['service']['name'] do
@@ -65,5 +66,6 @@ else
     retry_delay node['filebeat']['service']['retry_delay']
     supports :status => true, :restart => true
     action service_action
+    ignore_failure node['filebeat']['service']['ignore_failure']
   end
 end

--- a/templates/default/filebeat/start-stop-filebeat.sh.erb
+++ b/templates/default/filebeat/start-stop-filebeat.sh.erb
@@ -7,7 +7,7 @@ NAME=<%= @name %>
 
 PIDFILE="/var/run/${NAME}.pid"
 DAEMON=<%= @daemon_path %>
-ARGS="-c <%= @conf_path %>"
+ARGS="-c <%= @conf_path %> <%= node['filebeat']['service']['additional_command_line_options'] %>"
 
 start() {
     echo -n $"Starting $NAME: "


### PR DESCRIPTION
Comes in handy to use any of the command line args & flags that Filebeat offers;
e.g. for the HTTP profiler.