### PR TITLE
Correct default file path for `filebeat_config` lwrp

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ filebeat_config 'default' do
 end
 ```
 
-Above LWRP Resource will create a file `/etc/filebeat/conf.d/lwrp-prospector-messages_log.yml` with content:
+Above LWRP Resource will create a file `/etc/filebeat/filebeat.yml` with content:
 
 ```yaml
 filebeat.modules: []


### PR DESCRIPTION
It looks like a copy-paste error has introduced an incorrect path where we detail the usage of the `filebeat_config` lwrp.  

Currently it is the same path as the `filebeat_prospector` example which is below it. This MR updates it to the correct path, which is already mentioned further up in the docs for this LWRP.