### PR TITLE
adding property for prefix in prospector yaml filename

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 filebeat CHANGELOG
 ==================
 
+2.3.0
+-----
+
+- Piotr Kantyka - Added property for prefix in prospector yaml filename
+
 2.2.0
 -----
 

--- a/README.md
+++ b/README.md
@@ -209,23 +209,13 @@ filebeat.config_dir: "/etc/filebeat/conf.d"
 - *conf_file* (optional, String, NilClass) - default `nil`, filebeat configuration file, this attribute is derived by helper method
 - *disable_service* (optional, Boolean) - default `false`, set to `true`, to disable filebeat service
 - *notify_restart* (optional, Boolean) - default `true`, set to `false`, to ignore filebeat service restart notify
+- *prefix* (optional, String) - default `lwrp-prospector-`, filebeat prospecteor filename prefix, set to '' if no prefix is desired
 
 
 ## LWRP filebeat_prospector
 
 LWRP `filebeat_prospector` creates a filebeat prospector configuration yaml file under prospectors directory with file name `lwrp-prospector-#{resource_name}.yml`.
-`lwrp-prospector-` prefix can be changed with `default['filebeat']['prospector']['prefix']` attribute:
-
-```ruby
-default['filebeat']['prospector']['prefix'] = 'some-custom-prefix-'
-```
-
-or to disable the prefix:
-
-```ruby
-default['filebeat']['prospector']['prefix'] = ''
-```
-
+`lwrp-prospector-` prefix can be changed with `prefix` property (see above).
 
 **LWRP example**
 
@@ -240,10 +230,11 @@ conf = {
 filebeat_prospector 'messages_log' do
   config conf
   action :create
+  prefix 'my-custom-prefix-'
 end
 ```
 
-Above LWRP Resource will create a file `/etc/filebeat/conf.d/lwrp-prospector-messages_log.yml` with content:
+Above LWRP Resource will create a file `/etc/filebeat/conf.d/my-custom-prefix-messages_log.yml` with content:
 
 ```yaml
 filebeat:

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ filebeat.config_dir: "/etc/filebeat/conf.d"
 
 ## LWRP filebeat_prospector
 
-LWRP `filebeat_prospector` creates a filebeat prospector configuration yaml file under prospectors directory with file name `lwrp-prospector-#{resource_name}.yml`.
+LWRP `filebeat_prospector` creates a filebeat prospector configuration yaml file under prospectors directory with file name `#{resource_name}.yml`.
 
 
 **LWRP example**
@@ -232,7 +232,7 @@ filebeat_prospector 'messages_log' do
 end
 ```
 
-Above LWRP Resource will create a file `/etc/filebeat/conf.d/lwrp-prospector-messages_log.yml` with content:
+Above LWRP Resource will create a file `/etc/filebeat/conf.d/messages_log.yml` with content:
 
 ```yaml
 filebeat:

--- a/README.md
+++ b/README.md
@@ -213,7 +213,18 @@ filebeat.config_dir: "/etc/filebeat/conf.d"
 
 ## LWRP filebeat_prospector
 
-LWRP `filebeat_prospector` creates a filebeat prospector configuration yaml file under prospectors directory with file name `#{resource_name}.yml`.
+LWRP `filebeat_prospector` creates a filebeat prospector configuration yaml file under prospectors directory with file name `lwrp-prospector-#{resource_name}.yml`.
+`lwrp-prospector-` prefix can be changed with `default['filebeat']['prospector']['prefix']` attribute:
+
+```ruby
+default['filebeat']['prospector']['prefix'] = 'some-custom-prefix-'
+```
+
+or to disable the prefix:
+
+```ruby
+default['filebeat']['prospector']['prefix'] = ''
+```
 
 
 **LWRP example**
@@ -232,7 +243,7 @@ filebeat_prospector 'messages_log' do
 end
 ```
 
-Above LWRP Resource will create a file `/etc/filebeat/conf.d/messages_log.yml` with content:
+Above LWRP Resource will create a file `/etc/filebeat/conf.d/lwrp-prospector-messages_log.yml` with content:
 
 ```yaml
 filebeat:

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,1 +1,0 @@
-default['filebeat']['prospector']['prefix'] = 'lwrp-prospector-'

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,0 +1,1 @@
+default['filebeat']['prospector']['prefix'] = 'lwrp-prospector-'

--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -5,9 +5,10 @@ module Filebeat
   module Helpers
     def purge_prospectors_config(prospectors_dir)
       valid_prospectors = []
+      prospector_prefix = node['filebeat']['prospector']['prefix']
 
       # collect lwrp filebeat_prospector prospectors
-      run_context.resource_collection.select { |resource| valid_prospectors.push("#{resource.name}.yml") if resource.resource_name == :filebeat_prospector }
+      run_context.resource_collection.select { |resource| valid_prospectors.push("#{prospector_prefix}#{resource.name}.yml") if resource.resource_name == :filebeat_prospector }
 
       # prospectors yml files to clean up
       extra_prospectors = Dir.entries(prospectors_dir).reject { |a| valid_prospectors.include?(a) || a.match(/^custom-prospector-.*yml$/) }.sort

--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -5,10 +5,9 @@ module Filebeat
   module Helpers
     def purge_prospectors_config(prospectors_dir)
       valid_prospectors = []
-      prospector_prefix = node['filebeat']['prospector']['prefix']
 
       # collect lwrp filebeat_prospector prospectors
-      run_context.resource_collection.select { |resource| valid_prospectors.push("#{prospector_prefix}#{resource.name}.yml") if resource.resource_name == :filebeat_prospector }
+      run_context.resource_collection.select { |resource| valid_prospectors.push("#{resource.prefix}#{resource.name}.yml") if resource.resource_name == :filebeat_prospector }
 
       # prospectors yml files to clean up
       extra_prospectors = Dir.entries(prospectors_dir).reject { |a| valid_prospectors.include?(a) || a.match(/^custom-prospector-.*yml$/) }.sort

--- a/libraries/helper.rb
+++ b/libraries/helper.rb
@@ -7,7 +7,7 @@ module Filebeat
       valid_prospectors = []
 
       # collect lwrp filebeat_prospector prospectors
-      run_context.resource_collection.select { |resource| valid_prospectors.push("lwrp-prospector-#{resource.name}.yml") if resource.resource_name == :filebeat_prospector }
+      run_context.resource_collection.select { |resource| valid_prospectors.push("#{resource.name}.yml") if resource.resource_name == :filebeat_prospector }
 
       # prospectors yml files to clean up
       extra_prospectors = Dir.entries(prospectors_dir).reject { |a| valid_prospectors.include?(a) || a.match(/^custom-prospector-.*yml$/) }.sort

--- a/metadata.rb
+++ b/metadata.rb
@@ -4,7 +4,7 @@ maintainer_email 'vir.khatri@gmail.com'
 license 'Apache-2.0'
 description 'Installs/Configures Elastic Filebeat'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version '2.2.0'
+version '2.3.0'
 source_url 'https://github.com/vkhatri/chef-filebeat' if respond_to?(:source_url)
 issues_url 'https://github.com/vkhatri/chef-filebeat/issues' if respond_to?(:issues_url)
 chef_version '>= 12.14' if respond_to?(:chef_version)

--- a/resources/prospector.rb
+++ b/resources/prospector.rb
@@ -16,6 +16,8 @@ property :config_sensitive, [TrueClass, FalseClass], default: false
 
 default_action :create
 
+prospector_prefix = node['filebeat']['prospector']['prefix']
+
 action :create do
   install_preview_resource = check_beat_resource(Chef.run_context, :filebeat_install_preview, new_resource.filebeat_install_resource_name)
   install_resource = check_beat_resource(Chef.run_context, :filebeat_install, new_resource.filebeat_install_resource_name)
@@ -39,7 +41,7 @@ action :create do
 
   if new_resource.cookbook_file_name && new_resource.cookbook_file_name_cookbook
     cookbook_file "prospector_#{new_resource.name}" do
-      path ::File.join(filebeat_install_resource.prospectors_dir, "#{new_resource.name}.yml")
+      path ::File.join(filebeat_install_resource.prospectors_dir, "#{prospector_prefix}#{new_resource.name}.yml")
       source new_resource.cookbook_file_name
       cookbook new_resource.cookbook_file_name_cookbook
       notifies :restart, "service[#{new_resource.service_name}]" if new_resource.notify_restart && !new_resource.disable_service
@@ -48,7 +50,7 @@ action :create do
     end
   else
     file "prospector_#{new_resource.name}" do
-      path ::File.join(filebeat_install_resource.prospectors_dir, "#{new_resource.name}.yml")
+      path ::File.join(filebeat_install_resource.prospectors_dir, "#{prospector_prefix}#{new_resource.name}.yml")
       content file_content
       notifies :restart, "service[#{new_resource.service_name}]" if new_resource.notify_restart && !new_resource.disable_service
       mode 0o600
@@ -60,7 +62,7 @@ end
 action :delete do
   filebeat_install_resource = find_beat_resource(Chef.run_context, :filebeat_install, new_resource.filebeat_install_resource_name)
   file "prospector_#{new_resource.name}" do
-    path ::File.join(filebeat_install_resource.prospectors_dir, "#{new_resource.name}.yml")
+    path ::File.join(filebeat_install_resource.prospectors_dir, "#{prospector_prefix}#{new_resource.name}.yml")
     action :delete
   end
 end

--- a/resources/prospector.rb
+++ b/resources/prospector.rb
@@ -39,7 +39,7 @@ action :create do
 
   if new_resource.cookbook_file_name && new_resource.cookbook_file_name_cookbook
     cookbook_file "prospector_#{new_resource.name}" do
-      path ::File.join(filebeat_install_resource.prospectors_dir, "lwrp-prospector-#{new_resource.name}.yml")
+      path ::File.join(filebeat_install_resource.prospectors_dir, "#{new_resource.name}.yml")
       source new_resource.cookbook_file_name
       cookbook new_resource.cookbook_file_name_cookbook
       notifies :restart, "service[#{new_resource.service_name}]" if new_resource.notify_restart && !new_resource.disable_service
@@ -48,7 +48,7 @@ action :create do
     end
   else
     file "prospector_#{new_resource.name}" do
-      path ::File.join(filebeat_install_resource.prospectors_dir, "lwrp-prospector-#{new_resource.name}.yml")
+      path ::File.join(filebeat_install_resource.prospectors_dir, "#{new_resource.name}.yml")
       content file_content
       notifies :restart, "service[#{new_resource.service_name}]" if new_resource.notify_restart && !new_resource.disable_service
       mode 0o600
@@ -60,7 +60,7 @@ end
 action :delete do
   filebeat_install_resource = find_beat_resource(Chef.run_context, :filebeat_install, new_resource.filebeat_install_resource_name)
   file "prospector_#{new_resource.name}" do
-    path ::File.join(filebeat_install_resource.prospectors_dir, "lwrp-prospector-#{new_resource.name}.yml")
+    path ::File.join(filebeat_install_resource.prospectors_dir, "#{new_resource.name}.yml")
     action :delete
   end
 end

--- a/resources/prospector.rb
+++ b/resources/prospector.rb
@@ -7,6 +7,7 @@ resource_name :filebeat_prospector
 
 property :service_name, String, default: 'filebeat'
 property :filebeat_install_resource_name, String, default: 'default'
+property :prefix, String, default: 'lwrp-prospector-'
 property :config, [Array, Hash], default: {}
 property :cookbook_file_name, [String, NilClass], default: nil
 property :cookbook_file_name_cookbook, [String, NilClass], default: nil
@@ -16,7 +17,7 @@ property :config_sensitive, [TrueClass, FalseClass], default: false
 
 default_action :create
 
-prospector_prefix = node['filebeat']['prospector']['prefix']
+#prospector_prefix = node['filebeat']['prospector']['prefix']
 
 action :create do
   install_preview_resource = check_beat_resource(Chef.run_context, :filebeat_install_preview, new_resource.filebeat_install_resource_name)
@@ -41,7 +42,7 @@ action :create do
 
   if new_resource.cookbook_file_name && new_resource.cookbook_file_name_cookbook
     cookbook_file "prospector_#{new_resource.name}" do
-      path ::File.join(filebeat_install_resource.prospectors_dir, "#{prospector_prefix}#{new_resource.name}.yml")
+      path ::File.join(filebeat_install_resource.prospectors_dir, "#{prefix}#{new_resource.name}.yml")
       source new_resource.cookbook_file_name
       cookbook new_resource.cookbook_file_name_cookbook
       notifies :restart, "service[#{new_resource.service_name}]" if new_resource.notify_restart && !new_resource.disable_service
@@ -50,7 +51,7 @@ action :create do
     end
   else
     file "prospector_#{new_resource.name}" do
-      path ::File.join(filebeat_install_resource.prospectors_dir, "#{prospector_prefix}#{new_resource.name}.yml")
+      path ::File.join(filebeat_install_resource.prospectors_dir, "#{prefix}#{new_resource.name}.yml")
       content file_content
       notifies :restart, "service[#{new_resource.service_name}]" if new_resource.notify_restart && !new_resource.disable_service
       mode 0o600
@@ -62,7 +63,7 @@ end
 action :delete do
   filebeat_install_resource = find_beat_resource(Chef.run_context, :filebeat_install, new_resource.filebeat_install_resource_name)
   file "prospector_#{new_resource.name}" do
-    path ::File.join(filebeat_install_resource.prospectors_dir, "#{prospector_prefix}#{new_resource.name}.yml")
+    path ::File.join(filebeat_install_resource.prospectors_dir, "#{prefix}#{new_resource.name}.yml")
     action :delete
   end
 end

--- a/resources/prospector.rb
+++ b/resources/prospector.rb
@@ -17,8 +17,6 @@ property :config_sensitive, [TrueClass, FalseClass], default: false
 
 default_action :create
 
-#prospector_prefix = node['filebeat']['prospector']['prefix']
-
 action :create do
   install_preview_resource = check_beat_resource(Chef.run_context, :filebeat_install_preview, new_resource.filebeat_install_resource_name)
   install_resource = check_beat_resource(Chef.run_context, :filebeat_install, new_resource.filebeat_install_resource_name)


### PR DESCRIPTION
I see no sense in adding **lwrp-prospector-** prefix to filename. Such result:

```
httpd_access.yml
httpd_error.yml
solr.yml
syslog.yml
tomcat_catalina_out.yml
tomcat_feeds.yml
tomcat_localhost_access.yml
tomcat_search_engine.yml
tomcat_search_indexer.yml
```
seems to me much cleaner then:
```
lwrp-prospector-httpd_access.yml
lwrp-prospector-httpd_error.yml
lwrp-prospector-solr.yml
lwrp-prospector-syslog.yml
lwrp-prospector-tomcat_catalina_out.yml
lwrp-prospector-tomcat_feeds.yml
lwrp-prospector-tomcat_localhost_access.yml
lwrp-prospector-tomcat_search_engine.yml
lwrp-prospector-tomcat_search_indexer.yml
```