### PR TITLE
Update the minimum chef_version to 13.3

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -7,7 +7,7 @@ long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version '2.3.0'
 source_url 'https://github.com/vkhatri/chef-filebeat' if respond_to?(:source_url)
 issues_url 'https://github.com/vkhatri/chef-filebeat/issues' if respond_to?(:issues_url)
-chef_version '>= 12.14' if respond_to?(:chef_version)
+chef_version '>= 13.3' if respond_to?(:chef_version)
 
 depends 'homebrew', '~> 4.2'
 depends 'elastic_repo', '>= 1.1.1'


### PR DESCRIPTION
Using apt_preference requires a version >= 13.3 (https://docs.chef.io/resource_apt_preference.html)