### PR TITLE
Fix runit service with an alternative service name has been specified

### DIFF
--- a/resources/runit_service.rb
+++ b/resources/runit_service.rb
@@ -56,6 +56,7 @@ action :create do
     default_logger true
     action service_action
     ignore_failure new_resource.service_ignore_failure
+    run_template_name 'filebeat' # use sv-filebeat-run.erb as the run file
     cookbook 'filebeat'
   end
 end


### PR DESCRIPTION
The runit cookbook uses a template based on the service name to configure the service, so we need to override the default and always use the filebeat template in the cookbook.