### PR TITLE
Fixes Windows issue where filebeats service is reinstalled on each run

### DIFF
--- a/resources/install.rb
+++ b/resources/install.rb
@@ -79,10 +79,12 @@ action :create do
       source package_file
       action :unzip
       not_if { ::File.exist?(new_resource.conf_dir + '/install-service-filebeat.ps1') }
+      notifies :run, 'powershell_script[install filebeat as service]', :immediately
     end
 
     powershell_script 'install filebeat as service' do
       code "& '#{new_resource.conf_dir}/install-service-filebeat.ps1'"
+      action :nothing
     end
   end
 

--- a/spec/unit/recipes/default_spec.rb
+++ b/spec/unit/recipes/default_spec.rb
@@ -99,7 +99,8 @@ describe 'filebeat::lwrp_test' do
     end
 
     it 'run powershell_script to install filebeat as service' do
-      expect(chef_run).to run_powershell_script('install filebeat as service')
+      expect(chef_run.windows_zipfile('C:/opt/filebeat')).to notify('powershell_script[install filebeat as service]').to(:run).immediately
+      expect(chef_run).to_not run_powershell_script('install filebeat as service')
     end
   end
 


### PR DESCRIPTION
Hello,

This pull request fixes issue #134 .  Instead of having the `powershell_script 'install filebeat as service'` resource run every time, it only runs after `windows_zipfile` completes.

Testing shows this fixes the problem of the Windows service being stopped/deleted on every chef-client run. I'm also able to perform version upgrades with this code.

One note, this cookbook is affected by the issues below where versions of filebeat 6.4.0 and later cannot be uncompressed with the windows_zipfile resource. I did not try to resolve that issue here, so specifying version 6.3.2 or earlier is needed to test.

https://github.com/chef-cookbooks/windows/issues/459
https://github.com/elastic/beats/issues/9259