### PR TITLE
Fix config directory configuration for filebeat 6.0+

### DIFF
--- a/.kitchen.dokken.yml
+++ b/.kitchen.dokken.yml
@@ -35,7 +35,7 @@ platforms:
 
   - name: debian8
     driver:
-      image: debian:8.9
+      image: dokken/debian-8
       pid_one_command: /sbin/init
       intermediate_instructions:
         - RUN /usr/bin/apt-get update -qq

--- a/resources/prospector.rb
+++ b/resources/prospector.rb
@@ -33,7 +33,12 @@ action :create do
   end
 
   # file_content = { 'filebeat' => { 'prospectors' => config } }.to_yaml
-  file_content = JSON.parse({ 'filebeat' => { 'prospectors' => config } }.to_json).to_yaml.lines.to_a[1..-1].join
+  file_content =
+    if filebeat_install_resource.version.to_f >= 6.3
+      JSON.parse(config.to_json).to_yaml.lines.to_a[1..-1].join
+    else
+      JSON.parse({ 'filebeat' => { 'prospectors' => config } }.to_json).to_yaml.lines.to_a[1..-1].join
+    end
 
   # ...and put this back the way we found them.
   YAML::ENGINE.yamler = defaultengine if Psych::VERSION.start_with?('1')

--- a/test/cookbooks/filebeat_test/README.md
+++ b/test/cookbooks/filebeat_test/README.md
@@ -1,4 +1,2 @@
 filebeat_test
 =====
-
-

--- a/test/smoke/v6/default.rb
+++ b/test/smoke/v6/default.rb
@@ -15,6 +15,15 @@ else
   end
 end
 
+describe file('/etc/filebeat/filebeat.yml') do
+  its('content') { should match 'filebeat.config.inputs' }
+end
+
+describe command('filebeat test config') do
+  its('exit_status') { should eq 0 }
+  its('stdout') { should match 'Config OK' }
+end
+
 describe package('filebeat') do
   it { should be_installed }
   its('version') { should match '6.4.2' }

--- a/test/smoke/v6runit/default.rb
+++ b/test/smoke/v6runit/default.rb
@@ -1,0 +1,4 @@
+describe command('filebeat test config') do
+  its('exit_status') { should eq 0 }
+  its('stdout') { should match 'Config OK' }
+end


### PR DESCRIPTION
- Filebeat 6.0 deprecated config_dir and moved to inputs

Travis failed with `no such image: centos:6.9: No such image: centos:6.9` type errors. Having run the tests locally everything passed so ¯\_(ツ)_/¯