### PR TITLE
add 'provides' for chef-client v16+ compatibility

### DIFF
--- a/resources/config.rb
+++ b/resources/config.rb
@@ -6,6 +6,7 @@
 default_config = { 'filebeat.inputs' => [], 'filebeat.prospectors' => [], 'filebeat.modules' => [], 'prospectors' => [] }
 
 resource_name :filebeat_config
+provides :filebeat_config
 
 property :service_name, String, default: 'filebeat'
 property :filebeat_install_resource_name, String, default: 'default'

--- a/resources/install.rb
+++ b/resources/install.rb
@@ -4,6 +4,7 @@
 #
 
 resource_name :filebeat_install
+provides :filebeat_install
 
 property :version, String, default: '7.6.2'
 property :release, String, default: '1'

--- a/resources/install_preview.rb
+++ b/resources/install_preview.rb
@@ -4,6 +4,7 @@
 #
 
 resource_name :filebeat_install_preview
+provides :filebeat_install_preview
 
 property :version, String, default: '6.0.0-rc2'
 property :service_name, String, default: 'filebeat'

--- a/resources/prospector.rb
+++ b/resources/prospector.rb
@@ -4,6 +4,7 @@
 #
 
 resource_name :filebeat_prospector
+provides :filebeat_prospector
 
 property :service_name, String, default: 'filebeat'
 property :filebeat_install_resource_name, String, default: 'default'

--- a/resources/runit_service.rb
+++ b/resources/runit_service.rb
@@ -4,6 +4,7 @@
 #
 
 resource_name :filebeat_runit_service
+provides :filebeat_runit_service
 
 property :service_name, String, default: 'filebeat'
 property :filebeat_install_resource_name, String, default: 'default'

--- a/resources/service.rb
+++ b/resources/service.rb
@@ -4,6 +4,7 @@
 #
 
 resource_name :filebeat_service
+provides :filebeat_service
 
 property :service_name, String, default: 'filebeat'
 property :filebeat_install_resource_name, String, default: 'default'


### PR DESCRIPTION
This will add a `provides` statement in all custom resources. This is needed for compatibility with `chef-client` v16+.

Reference: https://docs.chef.io/release_notes/#whats-new-in-16244
