### PR TITLE
add support for aarch64 install_preview

### DIFF
--- a/resources/install_preview.rb
+++ b/resources/install_preview.rb
@@ -34,10 +34,24 @@ action :create do
   end
 
   if platform_family?('fedora', 'rhel', 'amazon')
-    package_arch = node['kernel']['machine'] =~ /x86_64/ ? 'x86_64' : 'i686'
+    package_arch =
+      if node['kernel']['machine'] =~ /aarch64/
+        'aarch64'
+      elsif node['kernel']['machine'] =~ /x86_64/
+        'x86_64'
+      else
+        'i686'
+      end
     package_family = 'rpm'
   elsif platform_family?('debian')
-    package_arch = node['kernel']['machine'] =~ /x86_64/ ? 'amd64' : 'i386'
+    package_arch =
+      if node['kernel']['machine'] =~ /aarch64/
+        'arm64'
+      elsif node['kernel']['machine'] =~ /x86_64/
+        'amd64'
+      else
+        'i386'
+      end
     package_family = 'deb'
   else
     raise "platform_family #{node['platform_family']} not supported"


### PR DESCRIPTION
add support for aarch64 install_preview
[RPM](https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-7.10.2-aarch64.rpm)
[DEB](https://artifacts.elastic.co/downloads/beats/filebeat/filebeat-7.10.2-arm64.deb)